### PR TITLE
add tmp/pids dir during installation

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -160,6 +160,7 @@ ynh_setup_source --dest_dir="$final_path"
 # files in some cases.
 # But FOR THE LOVE OF GOD, do not allow r/x for "others" on the entire folder -
 # this will be treated as a security issue.
+mkdir -p "$final_path/tmp/pids"
 chmod 750 "$final_path"
 chmod -R o-rwx "$final_path"
 chown -R $app:www-data "$final_path"


### PR DESCRIPTION
## Problem

- Installation failed because web.pid couldn't written

## Solution

- Create the directory in the install script before perms are set

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
