### PR TITLE
add email since its non-standard

### DIFF
--- a/check_process
+++ b/check_process
@@ -3,6 +3,7 @@
 		domain="domain.tld"
 		path="/path"
 		admin="john"
+		email="admin@domain.tld"
 		language="fr"
 		is_public=1
 		password="1Strong-Password"


### PR DESCRIPTION
## Problem

- CI fails when it can't find `email` parameter

## Solution

- add email to manifest